### PR TITLE
Add notification when successfully importing or failed importing the config

### DIFF
--- a/apps/plugin/src/app/app.tsx
+++ b/apps/plugin/src/app/app.tsx
@@ -194,7 +194,7 @@ function App() {
           target="_blank"
           className="text-sm underline hover:opacity-80"
         >
-          <span>v0.2.0</span>
+          <span>v0.2.1</span>
         </a>
       </div>
     </div>

--- a/apps/plugin/src/app/app.tsx
+++ b/apps/plugin/src/app/app.tsx
@@ -39,6 +39,18 @@ function App() {
           });
         }
       },
+      onNotifySuccess: () => {
+        const message: FigmaMessage = {
+          type: "notify-success",
+        };
+        parent.postMessage({ pluginMessage: message }, "*");
+      },
+      onNotifyError: (_, event) => {
+        const message: FigmaMessage = {
+          type: "notify-error",
+        };
+        parent.postMessage({ pluginMessage: message }, "*");
+      },
     },
   });
 
@@ -63,7 +75,14 @@ function App() {
         machineSend({ type: "ON_READ_CONFIG", payload: { config } });
       })
       .catch((err) => {
-        alert("Error parsing config file");
+        setFile(null);
+        const message: FigmaMessage = {
+          type: "notify-error",
+          payload: {
+            message: "Error parsing config file. Please recheck your config!",
+          },
+        };
+        parent.postMessage({ pluginMessage: message }, "*");
       });
   };
 

--- a/apps/plugin/src/app/processConfig.fsm.ts
+++ b/apps/plugin/src/app/processConfig.fsm.ts
@@ -9,7 +9,7 @@ type MachineContext = {
 
 export const processConfigFSM = createMachine(
   {
-    /** @xstate-layout N4IgpgJg5mDOIC5QAUBOB7AxnWACAwugHYBmAllLgGIDKAsgHQCSEANmAMQDyAcgPoAlAKIBBACJ98vKkwDiAbQAMAXUSgADulhkALmWJqQAD0QAmUwBYGigIwBWAGwXTNhw5sBmAOxeANCABPRABaOwY7C0U7Lw8bU1sbLxsADi87AF90-zQsHAJickpaRhZ2bn58YREAFSFJLgAZBqF8aqZeJVUkEE1tPQNukwQwgE4RxScLCwiRxyi7fyCEROSGB1MHCJtPLwdZj0zsjGxYPEJSCmp6BnxUMABDPSJKADd71DJ7gCN2WHK+IQCARcASdQy9XT6IiGIbBew2BgWewODwOCYbcyKPyBRB2UwjBhxOyKKJeTHTEaHEA5E5nAqXYo3O6PMjPXBvD7fX4cMHdCH9aGDMx2BEWNKKUxeRTJCweYkORa4jyKBio0zy5JuaYiqk0vLnQpXRi3B5PSiYdCsdiYAX-GQ8Jg0AASkiqtXqTRabQ6KnBWkhA1AsPMDHxMpSimmkY8I2mioQHgsDgYyUUsYlSbsyXiByy1OO+vpRWuJpZbItVrANqh-0BwNBvr5-oFMJC8MRyNR6PW8WxS1MqdVdhGHmSyTlNim0cyeaI6AgcEMetO+Quxbofr6UNbCDhYw7ji76x7WPjwRH1gH0ri6xGDmzXl1BZXBoZ11KYE3AcFQcQaPjIyrBYI5pPY6qpMklJ5sudJrkaTKmqyrzvJ8PyLk2W6BsYiCrDKEzOCM+JYkkFjJPGxJhOsKReLMPgog4j7Qc+sGGoypZmrgFbWi2GHfjuiYpt4pGysOXhIi48amKOaxyneiYxrGk4zukQA */
+    /** @xstate-layout N4IgpgJg5mDOIC5QAUBOB7AxnWACAwugHYBmAllLgGIDKAsgHQCSEANmAMQDyAcgPoAlAKIBBACJ98vKkwDiAbQAMAXUSgADulhkALmWJqQAD0QAmUwBYGigIwBWAGwXTNhw5sBmAOxeANCABPRABaOwY7C0U7Lw8bU1sbLxsADi87AF90-zQsHAJickpaRhZ2bn58YREAFSFJLgAZBqF8aqZeJVUkEE1tPQNukwQwgE4RxScLCwiRxyi7fyCEROSGB1MHCJtPLwdZj0zsjGxYPEJSCmp6BnxUMABDPSJKADd71DJ7gCN2WHK+IQCARcASdQy9XT6IiGIbBew2BgWewODwOCYbcyKPyBRB2UwjBhxOyKKJeTHTEaHEA5E5nAqXYo3O6PMjPXBvD7fX4cMHdCH9aGDRAeeJrWbJUx2EZ7Cwoxa4jyKBjJPaSyLJPGoqk0vLnQpXRi3B5PSiYdCsdiYAX-GQ8Jg0AASkiqtXqTRabQ6KnBWkhA1AsPMDHxySRyUU0wjHhG03lCA8suVihjiksmwligOWWpx119KK1yNLLZZotYCtUP+gOBoO9fN9AphIXhiORHjxpm8dhs0rjnYJ6cUGs2ksc0u1udO+QuBcYPHQehIAVwsAArphaTy6xoG1Cm-HRXtoslw+5olMPHHkeFnMSNeYRpYsZls0R0BA4IYdVO9Qz6D6+j3IUEDhMZW0cVF0XWeJsSWYJH2VFELHDNIyWjVwJ1yH98wNZg2DAAC-UFANEDROMRlWCwRi7exJVSZJKWzb86RnXCixNdl3k+H5P3rQD-WMRBVlDCZnEfcYfBsZC42JMJ1hSLxZh8FEHC8TDaWnfVGXY1lTXNS1Gz4oj9wTZVvGQix2xGLwkRcPsPFWFEpSQ6MYyk9S81Yxl50XZc1w3HBCMMkiEHxMJRJPVNkhSOI5RxULkPCNFogTTYpNMGyX3SIA */
     id: "Process Config FSM",
 
     tsTypes: {} as import("./processConfig.fsm.typegen").Typegen0,
@@ -33,10 +33,13 @@ export const processConfigFSM = createMachine(
         entry: "onCreateVariables",
 
         on: {
-          ON_ERROR: "Idle",
+          ON_ERROR: {
+            target: "Idle",
+            actions: "onNotifyError",
+          },
         },
 
-        always: "Idle",
+        always: "Notify success",
       },
 
       "Creating collection": {
@@ -45,10 +48,18 @@ export const processConfigFSM = createMachine(
             target: "Creating variables",
             actions: "assignCollectionIdToContext",
           },
-          ON_ERROR: "Idle",
+          ON_ERROR: {
+            target: "Idle",
+            actions: "onNotifyError",
+          },
         },
 
         entry: "onCreateCollection",
+      },
+
+      "Notify success": {
+        always: "Idle",
+        entry: "onNotifySuccess",
       },
     },
 

--- a/apps/plugin/src/app/processConfig.fsm.typegen.ts
+++ b/apps/plugin/src/app/processConfig.fsm.typegen.ts
@@ -3,11 +3,16 @@
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
+    "": { type: "" };
     "xstate.init": { type: "xstate.init" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
-    actions: "onCreateCollection" | "onCreateVariables";
+    actions:
+      | "onCreateCollection"
+      | "onCreateVariables"
+      | "onNotifyError"
+      | "onNotifySuccess";
     delays: never;
     guards: never;
     services: never;
@@ -17,10 +22,16 @@ export interface Typegen0 {
     assignConfigToContext: "ON_READ_CONFIG";
     onCreateCollection: "ON_CREATE_COLLECTION";
     onCreateVariables: "ON_FINISH_CREATE_COLLECTION";
+    onNotifyError: "ON_ERROR";
+    onNotifySuccess: "";
   };
   eventsCausingDelays: {};
   eventsCausingGuards: {};
   eventsCausingServices: {};
-  matchesStates: "Creating collection" | "Creating variables" | "Idle";
+  matchesStates:
+    | "Creating collection"
+    | "Creating variables"
+    | "Idle"
+    | "Notify success";
   tags: never;
 }

--- a/apps/plugin/src/code.ts
+++ b/apps/plugin/src/code.ts
@@ -63,6 +63,20 @@ figma.ui.onmessage = async (msg) => {
     );
   }
 
+  if (msg.type === "notify-success") {
+    figma.notify("Successfully imported the variables!");
+  }
+
+  if (msg.type === "notify-error") {
+    const message = msg as Extract<FigmaMessage, { type: "notify-error" }>;
+    figma.notify(
+      message?.payload?.message
+        ? message?.payload?.message
+        : "Can't create variables! Unknown error",
+      { error: true }
+    );
+  }
+
   // Make sure to close the plugin when you're done. Otherwise the plugin will
   // keep running, which shows the cancel button at the bottom of the screen.
   // figma.closePlugin();

--- a/apps/plugin/src/messages.ts
+++ b/apps/plugin/src/messages.ts
@@ -17,6 +17,15 @@ export type FigmaMessage =
       };
     }
   | {
+      type: "notify-success";
+    }
+  | {
+      type: "notify-error";
+      payload?: {
+        message: string;
+      };
+    }
+  | {
       type: "return-collection-id";
       payload: {
         collectionId: string;

--- a/apps/plugin/src/tests/error.json
+++ b/apps/plugin/src/tests/error.json
@@ -1,0 +1,8 @@
+{
+  "collectionName": "Your collection name",
+  "variables": [
+    {
+      "name": "Neutral Black"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Closes: https://github.com/insanistcontributor/suvarman/issues/6

## What?

Add notification when successfully importing the config or failed to import the config.

## Why?

Giving context to the user

## How?

1. Update the FSM
2. Add `notify-error` message

# Demo (optional)

## After
![CleanShot 2023-09-16 at 12 23 16](https://github.com/insanistcontributor/suvarman/assets/15979404/cdfb95fa-d972-40fc-a770-b1dfb6a15370)
![CleanShot 2023-09-16 at 12 23 33](https://github.com/insanistcontributor/suvarman/assets/15979404/8c427eb8-067d-4793-953f-8fdd12375d3d)

